### PR TITLE
Slightly friendlier to use on Windows

### DIFF
--- a/anim_encoder.py
+++ b/anim_encoder.py
@@ -196,8 +196,12 @@ def generate_animation(anim_name):
     packed = packed[0:allocator.num_used_rows]
 
     misc.imsave(anim_name + "_packed_tmp.png", packed)
-    os.system("pngcrush -q " + anim_name + "_packed_tmp.png " + anim_name + "_packed.png")
-    os.system("rm " + anim_name + "_packed_tmp.png")
+    # Don't completely fail if we don't have pngcrush
+    if os.system("pngcrush -q " + anim_name + "_packed_tmp.png " + anim_name + "_packed.png") == 0:
+        os.system("rm " + anim_name + "_packed_tmp.png")
+    else:
+        print "pngcrush not found, output will not be larger"
+        os.system("mv " + anim_name + "_packed_tmp.png " + anim_name + "_packed.png")
 
     # Generate JSON to represent the data
     times = [t for t, f in frames]


### PR DESCRIPTION
These changes do the following:
- When looking for Python, use the environment variable with /usr/bin/env instead of assuming it is always in /usr/bin to accommodate for multiple install locations.
- Don't fail when running on a system without pngcrush. Instead, provide the *.png file before pngcrush was supposed to be run and warn the user that the file may not be optimally small.

They made the anim_encoder usable on my Windows/MSYS/Python setup. I have not tested the changes on a *nix system, but I don't think they'll break anything.
