### PR TITLE
Multiple fixes to Capture and anim_encoder

### DIFF
--- a/anim_encoder.py
+++ b/anim_encoder.py
@@ -128,15 +128,16 @@ def find_matching_rect(bitmap, num_used_rows, packed, src, sx, sy, w, h):
         return None
 
 def generate_animation(anim_name):
+    from PIL import Image
+
     frames = []
-    rex = re.compile("screen_([0-9]+).png")
+    rex = re.compile("screenshot_([0-9]+).png")
     for f in os.listdir(anim_name):
         m = re.search(rex, f)
         if m:
             frames.append((int(m.group(1)), anim_name + "/" + f))
     frames.sort()
-
-    images = [misc.imread(f) for t, f in frames]
+    images = [asarray(Image.open(f).convert('RGB')) for t, f in frames]
 
     zero = images[0] - images[0]
     pairs = zip([zero] + images[:-1], images)

--- a/capture.py
+++ b/capture.py
@@ -20,7 +20,7 @@ w = None
 sz = None
 
 def useScreenCapture():
-    return os.system("type screencaptured &> /dev/null") == 0
+    return os.system("type screencapture &> /dev/null") == 0
 
 def useGtk():
     global w, sz

--- a/capture.py
+++ b/capture.py
@@ -9,20 +9,54 @@ import gtk.gdk
 import time
 import sys
 import config
+import os
 
 
 print "Starting Capture"
 print "================"
 
-w = gtk.gdk.get_default_root_window()
-sz = w.get_size()
+captureMethod = None
+w = None
+sz = None
+
+def useScreenCapture():
+    try:
+        return os.system("typeof screencapture")
+        return True
+    except StandError:
+        return False
+
+def useGtk():
+    try:
+        import gtk
+        w = gtk.gdk.get_default_root_window()
+        sz = w.get_size()
+
+        return True
+    except StandardError:
+        return False
+
+def takeScreenshot():
+    if captureMethod == None:
+        if useScreenCapture():
+            captureMethod = "screen"
+        elif useGtk():
+            captureMethod = "gtk"
+        else:
+            print "No capture methods available"
+            sys.exit(1)
+    
+    if captureMethod == "screen":
+        os.system("screencapture capture/screenshot_" + str(int(time.time())) + ".png")
+    elif captureMethod == "gtk":
+        pb = gtk.gdk.Pixbuf(gtk.gdk.COLORSPACE_RGB,False,8,sz[0],sz[1])
+        pb = pb.get_from_drawable(w,w.get_colormap(),0,0,0,0,sz[0],sz[1])
+        if (pb != None):
+            pb.save("capture/screenshot_"+ str(int(time.time())) +".png","png")
+            print "Screenshot " + str(i) + " saved."
+        else:
+            print "Unable to get the screenshot."
 
 for i in xrange(0, config.CAPTURE_NUM):
-  pb = gtk.gdk.Pixbuf(gtk.gdk.COLORSPACE_RGB,False,8,sz[0],sz[1])
-  pb = pb.get_from_drawable(w,w.get_colormap(),0,0,0,0,sz[0],sz[1])
-  if (pb != None):
-    pb.save("capture/screenshot_"+ str(int(time.time())) +".png","png")
-    print "Screenshot " + str(i) + " saved."
-  else:
-    print "Unable to get the screenshot."
-  time.sleep(config.CAPTURE_DELAY)
+    takeScreenshot();
+    time.sleep(config.CAPTURE_DELAY)

--- a/capture.py
+++ b/capture.py
@@ -20,15 +20,12 @@ w = None
 sz = None
 
 def useScreenCapture():
-    try:
-        return os.system("typeof screencapture")
-        return True
-    except StandError:
-        return False
+    return os.system("type screencaptured &> /dev/null") == 0
 
 def useGtk():
+    global w, sz
     try:
-        import gtk
+        import gtk.gdk
         w = gtk.gdk.get_default_root_window()
         sz = w.get_size()
 
@@ -37,6 +34,7 @@ def useGtk():
         return False
 
 def takeScreenshot():
+    global captureMethod
     if captureMethod == None:
         if useScreenCapture():
             captureMethod = "screen"
@@ -49,6 +47,8 @@ def takeScreenshot():
     if captureMethod == "screen":
         os.system("screencapture capture/screenshot_" + str(int(time.time())) + ".png")
     elif captureMethod == "gtk":
+        import gtk.gdk
+
         pb = gtk.gdk.Pixbuf(gtk.gdk.COLORSPACE_RGB,False,8,sz[0],sz[1])
         pb = pb.get_from_drawable(w,w.get_colormap(),0,0,0,0,sz[0],sz[1])
         if (pb != None):


### PR DESCRIPTION
Fixes the mismatch in filenames between capture (which makes screen_time.png) and anim_encoder (which expects screenshot_time.png).

Fixes having PNGs with alpha channels breaking anim_encoder.

Fixes issue with gtk on OSX.  Does this by instead running screencapture command when available.  Falls back to gtk if screencapture is not available.
