### PR TITLE
fixes error TypeError: XXX is not JSON serializable

### DIFF
--- a/anim_encoder.py
+++ b/anim_encoder.py
@@ -220,7 +220,7 @@ def generate_animation(anim_name):
             w, h = b.stop - b.start, a.stop - a.start
             dy, dx = dst_rects[j]
 
-            blitlist.append([dx, dy, w, h, sx, sy])
+            blitlist.append([int(dx), int(dy), int(w), int(h), int(sx), int(sy)])
 
         timeline.append({'delay': delays[i], 'blit': blitlist})
 


### PR DESCRIPTION
the JSON encoder was erroring out on some values because they were of type 'long' and appending an 'L' to the end of everything.